### PR TITLE
Allows running copier with gh link as direct source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist-types

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You need to configure the action in your backend:
 
 ```bash
 # From your Backstage root directory
-yarn add --cwd packages/backend https://github.com/DiamondLightSource/scaffolder-backend-module-copier.git
+yarn add --cwd packages/backend @diamondlightsource/plugin-scaffolder-backend-module-copier
 ```
 
 Configure the action within `packages/backend/src/plugins/scaffolder.ts`:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You can also visit the `/create/actions` route in your Backstage application to 
 
 ### Environment setup
 
-While running Backstage from a Docker container, you need to have `copier` installed within your image.
+The environment needs to have `copier` installed and be available in the `PATH`.
 
 You can do so by including the following lines in the last step of your Dockerfile:
 

--- a/src/actions/fetch/copier.test.ts
+++ b/src/actions/fetch/copier.test.ts
@@ -81,7 +81,6 @@ describe('fetch:copier', () => {
 
   const action = createFetchCopierAction({
     integrations,
-    containerRunner,
     reader: mockReader,
   });
 

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -71,18 +71,6 @@ export class CopierRunner {
     await fs.ensureDir(intermediateDir);
     const resultDir = path.join(workspacePath, 'result');
 
-    // First lets grab the default copier.json file
-    const copierJson = await this.fetchTemplateCopier(
-      templateContentsDir,
-    );
-
-    const copierInfo = {
-      ...copierJson,
-      ...values,
-    };
-
-    await fs.writeJSON(path.join(templateDir, 'copier.json'), copierInfo);
-
     // Directories to bind on container
     const mountDirs = {
       [templateDir]: '/input',

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  ContainerRunner,
   UrlReader,
   resolveSafeChildPath,
 } from '@backstage/backend-common';
@@ -32,12 +31,6 @@ import {
 } from '@backstage/plugin-scaffolder-node'
 
 export class CopierRunner {
-  private readonly containerRunner?: ContainerRunner;
-
-  constructor({ containerRunner }: { containerRunner?: ContainerRunner }) {
-    this.containerRunner = containerRunner;
-  }
-
   public async run({
     workspacePath,
     values,
@@ -99,9 +92,8 @@ export class CopierRunner {
 export function createFetchCopierAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
-  containerRunner?: ContainerRunner;
 }) {
-  const { reader, containerRunner, integrations } = options;
+  const { reader, integrations } = options;
 
   return createTemplateAction<{
     url: string;
@@ -162,7 +154,7 @@ export function createFetchCopierAction(options: {
         outputPath: templateContentsDir,
       });
 
-      const copier = new CopierRunner({ containerRunner });
+      const copier = new CopierRunner();
       const values = {
         ...ctx.input.values 
       };

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -82,29 +82,11 @@ export class CopierRunner {
       copierValues.push(key + "=" + value)
     }
     const projectDestination = intermediateDir+"/copier"
-    if (copierInstalled) {
-      await executeShellCommand({
-        command: 'copier',
-        args: ['copy', ...copierValues, templateContentsDir, projectDestination, '--trust'],
-        logStream,
-      });
-    } else {
-      if (this.containerRunner === undefined) {
-        throw new Error(
-          'Invalid state: containerRunner cannot be undefined when copier is not installed',
-        );
-      }
-
-      await this.containerRunner.runContainer({
-        imageName: imageName ?? 'tobiasestefors/copier:7.0.1',
-        command: 'copier',
-        args: [...copierValues, '/input', '/output'],
-        mountDirs, 
-        workingDir: '/input',
-        envVars: { HOME: '/tmp' },
-        logStream,
-      });
-    }
+    await executeShellCommand({
+      command: 'copier',
+      args: ['copy', ...copierValues, templateContentsDir, projectDestination, '--trust'],
+      logStream,
+    });
 
     const [generated] = await fs.readdir(intermediateDir);
     console.log(generated)

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -95,12 +95,11 @@ export class CopierRunner {
       copierValues.push("--data")
       copierValues.push(key + "=" + value)
     }
-    const templateSource = templateDir+"/copier"
     const projectDestination = intermediateDir+"/copier"
     if (copierInstalled) {
       await executeShellCommand({
         command: 'copier',
-        args: ['copy', ...copierValues, templateSource, projectDestination, '--trust'],
+        args: ['copy', ...copierValues, templateContentsDir, projectDestination, '--trust'],
         logStream,
       });
     } else {
@@ -191,6 +190,7 @@ export function createFetchCopierAction(options: {
       ctx.logger.info('Fetching and then templating using copier');
       const workDir = await ctx.createTemporaryDirectory();
       const templateDir = resolvePath(workDir, 'template');
+      const templateLocation = ctx.input.url;
       const templateContentsDir = resolvePath(
         templateDir,
         "copier", 
@@ -216,7 +216,7 @@ export function createFetchCopierAction(options: {
         values: values,
         imageName: ctx.input.imageName,
         templateDir: templateDir,
-        templateContentsDir: templateContentsDir,
+        templateContentsDir: templateLocation,
       });
 
       const targetPath = ctx.input.targetPath ?? './';

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -57,17 +57,6 @@ export class CopierRunner {
     await fs.ensureDir(intermediateDir);
     const resultDir = path.join(workspacePath, 'result');
 
-    // Directories to bind on container
-    const mountDirs = {
-      [templateDir]: '/input',
-      [intermediateDir]: '/output',
-    };
-
-    // the command-exists package returns `true` or throws an error
-    const copierInstalled = await commandExists('copier').catch(
-      () => false,
-    );
-
     let copierValues: string[] = []
     console.log(values) 
     let destValues = values['destination']

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -20,7 +20,6 @@ import {
 } from '@backstage/backend-common';
 import { JsonObject } from '@backstage/types';
 import { ScmIntegrations } from '@backstage/integration';
-import commandExists from 'command-exists';
 import fs from 'fs-extra';
 import path, { resolve as resolvePath } from 'path';
 import { Writable } from 'stream';
@@ -35,8 +34,6 @@ export class CopierRunner {
     workspacePath,
     values,
     logStream,
-    imageName,
-    templateDir,
     templateContentsDir,
   }: {
     workspacePath: string;

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -136,7 +136,7 @@ export function createFetchCopierAction(options: {
       ctx.logger.info('Fetching and then templating using copier');
       const workDir = await ctx.createTemporaryDirectory();
       const templateDir = resolvePath(workDir, 'template');
-      const templateLocation = ctx.input.url;
+      const templateUrl = ctx.input.url;
       const templateContentsDir = resolvePath(
         templateDir,
         "copier", 
@@ -162,7 +162,7 @@ export function createFetchCopierAction(options: {
         values: values,
         imageName: ctx.input.imageName,
         templateDir: templateDir,
-        templateContentsDir: templateLocation,
+        templateContentsDir: templateUrl,
       });
 
       const targetPath = ctx.input.targetPath ?? './';

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -19,7 +19,7 @@ import {
   UrlReader,
   resolveSafeChildPath,
 } from '@backstage/backend-common';
-import { JsonObject, JsonValue } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 import { ScmIntegrations } from '@backstage/integration';
 import commandExists from 'command-exists';
 import fs from 'fs-extra';

--- a/src/actions/fetch/copier.ts
+++ b/src/actions/fetch/copier.ts
@@ -38,20 +38,6 @@ export class CopierRunner {
     this.containerRunner = containerRunner;
   }
 
-  private async fetchTemplateCopier(
-    directory: string,
-  ): Promise<Record<string, JsonValue>> {
-    try {
-      return await fs.readJSON(path.join(directory, 'copier.json'));
-    } catch (ex) {
-      if (typeof ex === "object" && ex && "code" in ex && ex.code !== 'ENOENT') {
-        throw ex;
-      }
-
-      return {};
-    }
-  }
-
   public async run({
     workspacePath,
     values,


### PR DESCRIPTION
Doesn't clone the repo's contents but rather runs copier in the same way as the CLI taking the latest tag from a given url.
This removed the 'undefined' _commit issue and hence allows for updating the template in the future using `copier update`.

Also, simplifies the code as some code is no longer needed / used